### PR TITLE
Ansible playbook for Yandex Cloud VM setup

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,60 @@
+## Ansible Playbook for Yandex Cloud VM
+
+This playbook configures a VM with base packages (`git`, `curl`, etc.) and NGINX. It can serve static content or proxy to an upstream app.
+
+### Structure
+
+```
+infra/ansible/
+  ansible.cfg
+  site.yml
+  inventory/
+    local.ini
+    example_yc.ini
+  group_vars/
+    all.yml
+  roles/
+    common/
+      tasks/main.yml
+    nginx/
+      tasks/main.yml
+      handlers/main.yml
+      templates/default.j2
+```
+
+### Variables
+
+- `nginx_server_name`: server_name, default `_`
+- `nginx_listen_port`: default `80`
+- `nginx_app_root`: static root, default `/var/www/app/public`
+- `nginx_proxy_upstream`: if set (e.g. `http://127.0.0.1:3000`), NGINX proxies to it
+- `enable_ufw`: enable firewall management (default `false`)
+
+### Usage
+
+Local (for syntax check / dry run):
+
+```bash
+cd infra/ansible
+ansible-playbook -i inventory/local.ini site.yml --check -vv
+```
+
+Remote YC VM (replace IP and user/key as needed in `inventory/example_yc.ini`):
+
+```bash
+cd infra/ansible
+ANSIBLE_CONFIG=ansible.cfg ansible-playbook -i inventory/example_yc.ini site.yml -b -vv
+```
+
+To enable UFW:
+
+```bash
+ansible-playbook -i inventory/example_yc.ini site.yml -e enable_ufw=true -b
+```
+
+Logs are saved when you pipe output, e.g.:
+
+```bash
+ansible-playbook -i inventory/example_yc.ini site.yml -vv | tee ansible_run.log
+```
+

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,14 @@
+[defaults]
+inventory = inventory/local.ini
+stdout_callback = yaml
+bin_ansible_callbacks = True
+host_key_checking = False
+retry_files_enabled = False
+timeout = 30
+interpreter_python = auto_silent
+roles_path = roles
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+

--- a/infra/ansible/ansible_check.log
+++ b/infra/ansible/ansible_check.log
@@ -1,0 +1,205 @@
+ansible-playbook [core 2.16.14]
+  config file = /workspace/infra/ansible/ansible.cfg
+  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /home/ubuntu/.local/lib/python3.13/site-packages/ansible
+  ansible collection location = /home/ubuntu/.ansible/collections:/usr/share/ansible/collections
+  executable location = /home/ubuntu/.local/bin/ansible-playbook
+  python version = 3.13.3 (main, Apr  8 2025, 19:55:40) [GCC 14.2.0] (/usr/bin/python3)
+  jinja version = 3.1.6
+  libyaml = True
+Using /workspace/infra/ansible/ansible.cfg as config file
+host_list declined parsing /workspace/infra/ansible/inventory/local.ini as it did not pass its verify_file() method
+script declined parsing /workspace/infra/ansible/inventory/local.ini as it did not pass its verify_file() method
+auto declined parsing /workspace/infra/ansible/inventory/local.ini as it did not pass its verify_file() method
+yaml declined parsing /workspace/infra/ansible/inventory/local.ini as it did not pass its verify_file() method
+Parsed /workspace/infra/ansible/inventory/local.ini inventory source with ini plugin
+redirecting (type: modules) ansible.builtin.ufw to community.general.ufw
+redirecting (type: modules) ansible.builtin.ufw to community.general.ufw
+redirecting (type: modules) ansible.builtin.ufw to community.general.ufw
+redirecting (type: modules) ansible.builtin.ufw to community.general.ufw
+redirecting (type: callback) ansible.builtin.yaml to community.general.yaml
+redirecting (type: callback) ansible.builtin.yaml to community.general.yaml
+Skipping callback 'default', as we already have a stdout callback.
+Skipping callback 'minimal', as we already have a stdout callback.
+Skipping callback 'oneline', as we already have a stdout callback.
+
+PLAYBOOK: site.yml *************************************************************
+1 plays in site.yml
+
+PLAY [Configure web servers] ***************************************************
+
+TASK [Gathering Facts] *********************************************************
+task path: /workspace/infra/ansible/site.yml:1
+<localhost> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
+<localhost> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
+<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972 `" && echo ansible-tmp-1759055385.2620695-3997-102357677313972="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972 `" ) && sleep 0'
+<localhost> Attempting python interpreter discovery
+<localhost> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'python3.12'"'"'; command -v '"'"'python3.11'"'"'; command -v '"'"'python3.10'"'"'; command -v '"'"'python3.9'"'"'; command -v '"'"'python3.8'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
+<localhost> EXEC /bin/sh -c '/usr/bin/python3 && sleep 0'
+Using module file /home/ubuntu/.local/lib/python3.13/site-packages/ansible/modules/setup.py
+<localhost> PUT /home/ubuntu/.ansible/tmp/ansible-local-3992x4ocblag/tmp9xrhapzd TO /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972/AnsiballZ_setup.py
+<localhost> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972/ /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972/AnsiballZ_setup.py && sleep 0'
+<localhost> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-jtdhopwdibgnzmvyofbbhkiibuehiuhj ; /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972/AnsiballZ_setup.py'"'"' && sleep 0'
+<localhost> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.2620695-3997-102357677313972/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost]
+
+TASK [common : Update apt cache] ***********************************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:1
+skipping: [localhost] => changed=false 
+  false_condition: not ansible_check_mode
+  skip_reason: Conditional result was False
+
+TASK [common : Install base packages] ******************************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:9
+skipping: [localhost] => changed=false 
+  false_condition: not ansible_check_mode
+  skip_reason: Conditional result was False
+
+TASK [common : Ensure UFW installed when enabled] ******************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:24
+skipping: [localhost] => changed=false 
+  false_condition: enable_ufw | bool
+  skip_reason: Conditional result was False
+
+TASK [common : Allow SSH in UFW] ***********************************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:33
+skipping: [localhost] => changed=false 
+  false_condition: enable_ufw | bool
+  skip_reason: Conditional result was False
+
+TASK [common : Allow HTTP in UFW] **********************************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:41
+skipping: [localhost] => changed=false 
+  false_condition: enable_ufw | bool
+  skip_reason: Conditional result was False
+
+TASK [common : Allow HTTPS in UFW] *********************************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:50
+skipping: [localhost] => changed=false 
+  false_condition: enable_ufw | bool
+  skip_reason: Conditional result was False
+
+TASK [common : Enable UFW] *****************************************************
+task path: /workspace/infra/ansible/roles/common/tasks/main.yml:59
+skipping: [localhost] => changed=false 
+  false_condition: enable_ufw | bool
+  skip_reason: Conditional result was False
+
+TASK [nginx : Install NGINX] ***************************************************
+task path: /workspace/infra/ansible/roles/nginx/tasks/main.yml:1
+skipping: [localhost] => changed=false 
+  false_condition: not ansible_check_mode
+  skip_reason: Conditional result was False
+
+TASK [nginx : Create app root directory] ***************************************
+task path: /workspace/infra/ansible/roles/nginx/tasks/main.yml:9
+<localhost> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
+<localhost> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
+<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694 `" && echo ansible-tmp-1759055385.9457881-4067-67700333944694="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694 `" ) && sleep 0'
+Using module file /home/ubuntu/.local/lib/python3.13/site-packages/ansible/modules/file.py
+<localhost> PUT /home/ubuntu/.ansible/tmp/ansible-local-3992x4ocblag/tmp5lnysv9t TO /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694/AnsiballZ_file.py
+<localhost> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694/ /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694/AnsiballZ_file.py && sleep 0'
+<localhost> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-lawkwhftbdjjhrqtovwvezrayoqngrkd ; /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694/AnsiballZ_file.py'"'"' && sleep 0'
+<localhost> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1759055385.9457881-4067-67700333944694/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => changed=true 
+  diff:
+    after:
+      path: /var/www/app/public
+      state: directory
+    before:
+      path: /var/www/app/public
+      state: absent
+  invocation:
+    module_args:
+      _diff_peek: null
+      _original_basename: null
+      access_time: null
+      access_time_format: '%Y%m%d%H%M.%S'
+      attributes: null
+      follow: true
+      force: false
+      group: www-data
+      mode: '0755'
+      modification_time: null
+      modification_time_format: '%Y%m%d%H%M.%S'
+      owner: www-data
+      path: /var/www/app/public
+      recurse: false
+      selevel: null
+      serole: null
+      setype: null
+      seuser: null
+      src: null
+      state: directory
+      unsafe_writes: false
+  path: /var/www/app/public
+
+TASK [nginx : Deploy default index.html if no upstream] ************************
+task path: /workspace/infra/ansible/roles/nginx/tasks/main.yml:17
+<localhost> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
+<localhost> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
+<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633 `" && echo ansible-tmp-1759055386.1294503-4095-225997936153633="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633 `" ) && sleep 0'
+Using module file /home/ubuntu/.local/lib/python3.13/site-packages/ansible/modules/stat.py
+<localhost> PUT /home/ubuntu/.ansible/tmp/ansible-local-3992x4ocblag/tmp_37850ny TO /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633/AnsiballZ_stat.py
+<localhost> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633/ /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633/AnsiballZ_stat.py && sleep 0'
+<localhost> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-jjrjjynxtnylqrcestevjnccxedrcavs ; /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633/AnsiballZ_stat.py'"'"' && sleep 0'
+<localhost> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.1294503-4095-225997936153633/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => changed=true 
+  diff: []
+  invocation:
+    content: 'CENSORED: content is a no_log parameter'
+    dest: /var/www/app/public/index.html
+    group: www-data
+    mode: '0644'
+    module_args:
+      content: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
+      dest: /var/www/app/public/index.html
+      group: www-data
+      mode: '0644'
+      owner: www-data
+    owner: www-data
+
+TASK [nginx : Deploy nginx site config] ****************************************
+task path: /workspace/infra/ansible/roles/nginx/tasks/main.yml:31
+<localhost> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
+<localhost> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
+<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395 `" && echo ansible-tmp-1759055386.2998717-4123-20217270810395="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395 `" ) && sleep 0'
+Using module file /home/ubuntu/.local/lib/python3.13/site-packages/ansible/modules/stat.py
+<localhost> PUT /home/ubuntu/.ansible/tmp/ansible-local-3992x4ocblag/tmp1vg6iay3 TO /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395/AnsiballZ_stat.py
+<localhost> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395/ /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395/AnsiballZ_stat.py && sleep 0'
+<localhost> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-dkuirrbcfcvbhzjqsefktgqvqveimisi ; /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395/AnsiballZ_stat.py'"'"' && sleep 0'
+<localhost> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1759055386.2998717-4123-20217270810395/ > /dev/null 2>&1 && sleep 0'
+Notification for handler Reload nginx has been saved.
+changed: [localhost] => changed=true 
+  diff: []
+  invocation:
+    dest: /etc/nginx/sites-available/default
+    follow: false
+    group: root
+    mode: '0644'
+    module_args:
+      dest: /etc/nginx/sites-available/default
+      follow: false
+      group: root
+      mode: '0644'
+      owner: root
+      src: /home/ubuntu/.ansible/tmp/ansible-local-3992x4ocblag/tmpmcti97sz/default.j2
+    owner: root
+    src: /home/ubuntu/.ansible/tmp/ansible-local-3992x4ocblag/tmpmcti97sz/default.j2
+
+TASK [nginx : Ensure nginx is enabled and running] *****************************
+task path: /workspace/infra/ansible/roles/nginx/tasks/main.yml:40
+skipping: [localhost] => changed=false 
+  false_condition: not ansible_check_mode
+  skip_reason: Conditional result was False
+NOTIFIED HANDLER nginx : Reload nginx for localhost
+
+RUNNING HANDLER [nginx : Reload nginx] *****************************************
+task path: /workspace/infra/ansible/roles/nginx/handlers/main.yml:1
+skipping: [localhost] => changed=false 
+  false_condition: not ansible_check_mode
+  skip_reason: Conditional result was False
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=3    unreachable=0    failed=0    skipped=10   rescued=0    ignored=0   
+

--- a/infra/ansible/collections/requirements.yml
+++ b/infra/ansible/collections/requirements.yml
@@ -1,0 +1,4 @@
+collections:
+  - name: community.general
+    version: ">=8.0.0"
+

--- a/infra/ansible/group_vars/all.yml
+++ b/infra/ansible/group_vars/all.yml
@@ -1,0 +1,11 @@
+nginx_server_name: _
+nginx_listen_port: 80
+nginx_app_root: /var/www/app/public
+
+# If set (e.g. http://127.0.0.1:3000), NGINX will proxy to upstream.
+# If empty, NGINX will serve static content from nginx_app_root.
+nginx_proxy_upstream: ""
+
+# Firewall (UFW) management; disabled by default to avoid surprises
+enable_ufw: false
+

--- a/infra/ansible/inventory/example_yc.ini
+++ b/infra/ansible/inventory/example_yc.ini
@@ -1,0 +1,3 @@
+[web]
+203.0.113.10 ansible_user=yc-user ansible_ssh_private_key_file=~/.ssh/id_rsa ansible_become=yes
+

--- a/infra/ansible/inventory/local.ini
+++ b/infra/ansible/inventory/local.ini
@@ -1,0 +1,3 @@
+[web]
+localhost ansible_connection=local
+

--- a/infra/ansible/roles/common/tasks/main.yml
+++ b/infra/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,66 @@
+- name: Update apt cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+  when:
+    - ansible_os_family == 'Debian'
+    - not ansible_check_mode
+
+- name: Install base packages
+  apt:
+    name:
+      - git
+      - curl
+      - ca-certificates
+      - gnupg
+      - lsb-release
+      - python3-apt
+      - software-properties-common
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - not ansible_check_mode
+
+- name: Ensure UFW installed when enabled
+  apt:
+    name: ufw
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - enable_ufw | bool
+    - not ansible_check_mode
+
+- name: Allow SSH in UFW
+  ufw:
+    rule: allow
+    name: OpenSSH
+  when:
+    - ansible_os_family == 'Debian'
+    - enable_ufw | bool
+
+- name: Allow HTTP in UFW
+  ufw:
+    rule: allow
+    port: '80'
+    proto: tcp
+  when:
+    - ansible_os_family == 'Debian'
+    - enable_ufw | bool
+
+- name: Allow HTTPS in UFW
+  ufw:
+    rule: allow
+    port: '443'
+    proto: tcp
+  when:
+    - ansible_os_family == 'Debian'
+    - enable_ufw | bool
+
+- name: Enable UFW
+  ufw:
+    state: enabled
+    policy: deny
+  when:
+    - ansible_os_family == 'Debian'
+    - enable_ufw | bool
+

--- a/infra/ansible/roles/nginx/handlers/main.yml
+++ b/infra/ansible/roles/nginx/handlers/main.yml
@@ -1,0 +1,6 @@
+- name: Reload nginx
+  service:
+    name: nginx
+    state: reloaded
+  when: not ansible_check_mode
+

--- a/infra/ansible/roles/nginx/tasks/main.yml
+++ b/infra/ansible/roles/nginx/tasks/main.yml
@@ -1,0 +1,47 @@
+- name: Install NGINX
+  apt:
+    name: nginx
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - not ansible_check_mode
+
+- name: Create app root directory
+  file:
+    path: "{{ nginx_app_root }}"
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: '0755'
+
+- name: Deploy default index.html if no upstream
+  copy:
+    dest: "{{ nginx_app_root }}/index.html"
+    content: |
+      <!doctype html>
+      <html lang="en">
+      <head><meta charset="utf-8"><title>NGINX OK</title></head>
+      <body><h1>NGINX is up</h1></body>
+      </html>
+    owner: www-data
+    group: www-data
+    mode: '0644'
+  when: not nginx_proxy_upstream
+
+- name: Deploy nginx site config
+  template:
+    src: default.j2
+    dest: /etc/nginx/sites-available/default
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload nginx
+
+- name: Ensure nginx is enabled and running
+  service:
+    name: nginx
+    state: started
+    enabled: yes
+  when:
+    - not ansible_check_mode
+

--- a/infra/ansible/roles/nginx/templates/default.j2
+++ b/infra/ansible/roles/nginx/templates/default.j2
@@ -1,0 +1,25 @@
+server {
+    listen {{ nginx_listen_port }} default_server;
+    listen [::]:{{ nginx_listen_port }} default_server;
+    server_name {{ nginx_server_name }};
+
+    {% if nginx_proxy_upstream %}
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass {{ nginx_proxy_upstream }};
+    }
+    {% else %}
+    root {{ nginx_app_root }};
+    index index.html;
+    location / {
+        try_files $uri $uri/ =404;
+    }
+    {% endif %}
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+}
+

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -1,0 +1,9 @@
+- name: Configure web servers
+  hosts: all
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: common
+    - role: nginx
+


### PR DESCRIPTION
Implement an Ansible playbook to provision Yandex Cloud VMs, installing common dependencies and configuring NGINX for static content or proxying.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb815f19-7722-4bf4-8b52-3dfad0c660c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb815f19-7722-4bf4-8b52-3dfad0c660c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

