### PR TITLE
Ansible playbook for Yandex Cloud VM setup

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,114 @@
+# Ansible provisioning for Yandex Cloud VM
+
+This Ansible project configures a Yandex Cloud VM (or any Ubuntu/Debian host) with:
+
+- Nginx
+- Git
+- Base dependencies (curl, unzip, build-essential, python3, etc.)
+
+All configs live alongside the application repo in `ansible/`.
+
+## Project structure
+
+```
+ansible/
+  ansible.cfg
+  inventory/
+    local.ini
+    yc.ini
+  group_vars/
+    all.yml
+  playbooks/
+    site.yml
+  roles/
+    base/
+      tasks/main.yml
+    git/
+      tasks/main.yml
+    nginx/
+      defaults/main.yml
+      handlers/main.yml
+      tasks/main.yml
+      templates/site.conf.j2
+```
+
+## Requirements
+
+- Control node: Python 3.8+, Ansible 2.16+
+- SSH access to YC VM (e.g., `ubuntu` user with your SSH key)
+
+Install Ansible in a virtualenv (recommended):
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+pip install "ansible-core>=2.16,<2.17"
+ansible --version
+```
+
+## Inventory
+
+Edit `inventory/yc.ini` and set the external IP:
+
+```
+[yc]
+vm1 ansible_host=203.0.113.10 ansible_user=ubuntu
+```
+
+For local dry-run (no changes applied):
+
+```
+[local]
+localhost ansible_connection=local
+```
+
+## Variables
+
+Defaults are in `group_vars/all.yml`:
+
+- `app_user`: system user to own files (default: `app`)
+- `app_root_dir`: web root (default: `/var/www/app`)
+- `nginx_server_name`: server_name for nginx (default: `_`)
+- `nginx_site_name`: site id (default: `app`)
+- `nginx_listen_port`: default `80`
+- `enable_ufw`: enable firewall (default: `false`)
+
+Override on the command line if needed, e.g.:
+
+```bash
+ansible-playbook -i inventory/yc.ini playbooks/site.yml \
+  -e "nginx_server_name=example.com app_root_dir=/var/www/app"
+```
+
+## Run
+
+Syntax check:
+
+```bash
+ansible-playbook -i inventory/local.ini playbooks/site.yml --syntax-check
+```
+
+Local dry-run (check mode, no changes):
+
+```bash
+ansible-playbook -i inventory/local.ini playbooks/site.yml -C -vv
+```
+
+Run against Yandex Cloud VM:
+
+```bash
+ansible-playbook -i inventory/yc.ini playbooks/site.yml -vv
+```
+
+If your sudo requires a password, add `-K` to prompt.
+
+## Collections
+
+Install required collections into `collections/`:
+
+```bash
+ansible-galaxy collection install -r requirements.yml -p collections
+```
+
+

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,18 @@
+[defaults]
+inventory = inventory
+roles_path = roles
+host_key_checking = False
+timeout = 30
+interpreter_python = auto_silent
+retry_files_enabled = False
+stdout_callback = default
+bin_ansible_callbacks = True
+forks = 10
+deprecation_warnings = False
+command_warnings = False
+collections_paths = collections
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,0 +1,28 @@
+---
+app_user: app
+app_root_dir: /var/www/app
+nginx_server_name: _
+nginx_site_name: app
+nginx_listen_port: 80
+enable_ufw: false
+
+base_packages:
+  - ca-certificates
+  - curl
+  - unzip
+  - tar
+  - gnupg
+  - software-properties-common
+  - build-essential
+  - python3
+  - python3-pip
+  - python3-venv
+  - acl
+  - htop
+
+git_packages:
+  - git
+
+nginx_packages:
+  - nginx
+

--- a/ansible/inventory/local.ini
+++ b/ansible/inventory/local.ini
@@ -1,0 +1,3 @@
+[local]
+localhost ansible_connection=local ansible_become=false
+

--- a/ansible/inventory/yc.ini
+++ b/ansible/inventory/yc.ini
@@ -1,0 +1,3 @@
+[yc]
+vm1 ansible_host=CHANGE_ME ansible_user=ubuntu ansible_become=true ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+

--- a/ansible/logs/local_check.log
+++ b/ansible/logs/local_check.log
@@ -1,0 +1,190 @@
+2025-09-28T10:33:44+00:00 Starting local dry-run
+ansible-playbook [core 2.16.14]
+  config file = /workspace/ansible/ansible.cfg
+  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /workspace/ansible/.venv/lib/python3.13/site-packages/ansible
+  ansible collection location = /workspace/ansible/collections
+  executable location = /workspace/ansible/.venv/bin/ansible-playbook
+  python version = 3.13.3 (main, Aug 14 2025, 11:53:40) [GCC 14.2.0] (/workspace/ansible/.venv/bin/python)
+  jinja version = 3.1.6
+  libyaml = True
+Using /workspace/ansible/ansible.cfg as config file
+redirecting (type: callback) ansible.builtin.yaml to community.general.yaml
+ERROR! Invalid callback for stdout specified: yaml
+2025-09-28T10:34:14+00:00 Re-running local dry-run with default callback
+ansible-playbook [core 2.16.14]
+  config file = /workspace/ansible/ansible.cfg
+  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /workspace/ansible/.venv/lib/python3.13/site-packages/ansible
+  ansible collection location = /workspace/ansible/collections
+  executable location = /workspace/ansible/.venv/bin/ansible-playbook
+  python version = 3.13.3 (main, Aug 14 2025, 11:53:40) [GCC 14.2.0] (/workspace/ansible/.venv/bin/python)
+  jinja version = 3.1.6
+  libyaml = True
+Using /workspace/ansible/ansible.cfg as config file
+Skipping callback 'default', as we already have a stdout callback.
+Skipping callback 'minimal', as we already have a stdout callback.
+Skipping callback 'oneline', as we already have a stdout callback.
+
+PLAYBOOK: site.yml *************************************************************
+1 plays in playbooks/site.yml
+
+PLAY [Configure environment on servers] ****************************************
+
+TASK [Gathering Facts] *********************************************************
+task path: /workspace/ansible/playbooks/site.yml:2
+ok: [localhost]
+
+TASK [base : Ensure apt cache is up to date] ***********************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:2
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Install base packages] ********************************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:8
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Create application user] ******************************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:14
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Create application root directory] ********************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:22
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Optionally enable UFW and allow SSH and HTTP] *********************
+task path: /workspace/ansible/roles/base/tasks/main.yml:31
+fatal: [localhost]: FAILED! => {"msg": "The conditional check 'enable_ufw | bool' failed. The error was: error while evaluating conditional (enable_ufw | bool): 'enable_ufw' is undefined. 'enable_ufw' is undefined\n\nThe error appears to be in '/workspace/ansible/roles/base/tasks/main.yml': line 31, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Optionally enable UFW and allow SSH and HTTP\n  ^ here\n"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=4    rescued=0    ignored=0   
+
+2025-09-28T10:34:52+00:00 Re-running local dry-run after defaults
+ansible-playbook [core 2.16.14]
+  config file = /workspace/ansible/ansible.cfg
+  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /workspace/ansible/.venv/lib/python3.13/site-packages/ansible
+  ansible collection location = /workspace/ansible/collections
+  executable location = /workspace/ansible/.venv/bin/ansible-playbook
+  python version = 3.13.3 (main, Aug 14 2025, 11:53:40) [GCC 14.2.0] (/workspace/ansible/.venv/bin/python)
+  jinja version = 3.1.6
+  libyaml = True
+Using /workspace/ansible/ansible.cfg as config file
+Skipping callback 'default', as we already have a stdout callback.
+Skipping callback 'minimal', as we already have a stdout callback.
+Skipping callback 'oneline', as we already have a stdout callback.
+
+PLAYBOOK: site.yml *************************************************************
+1 plays in playbooks/site.yml
+
+PLAY [Configure environment on servers] ****************************************
+
+TASK [Gathering Facts] *********************************************************
+task path: /workspace/ansible/playbooks/site.yml:2
+ok: [localhost]
+
+TASK [base : Ensure apt cache is up to date] ***********************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:2
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Install base packages] ********************************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:8
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Create application user] ******************************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:14
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Create application root directory] ********************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:22
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Optionally enable UFW and allow SSH and HTTP] *********************
+task path: /workspace/ansible/roles/base/tasks/main.yml:31
+skipping: [localhost] => {"changed": false, "false_condition": "(enable_ufw | default(false)) | bool", "skip_reason": "Conditional result was False"}
+
+TASK [git : Install git packages] **********************************************
+task path: /workspace/ansible/roles/git/tasks/main.yml:2
+fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'git_packages' is undefined. 'git_packages' is undefined\n\nThe error appears to be in '/workspace/ansible/roles/git/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Install git packages\n  ^ here\n"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=5    rescued=0    ignored=0   
+
+2025-09-28T10:35:57+00:00 Re-running local dry-run after inventory group_vars move
+ansible-playbook [core 2.16.14]
+  config file = /workspace/ansible/ansible.cfg
+  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /workspace/ansible/.venv/lib/python3.13/site-packages/ansible
+  ansible collection location = /workspace/ansible/collections
+  executable location = /workspace/ansible/.venv/bin/ansible-playbook
+  python version = 3.13.3 (main, Aug 14 2025, 11:53:40) [GCC 14.2.0] (/workspace/ansible/.venv/bin/python)
+  jinja version = 3.1.6
+  libyaml = True
+Using /workspace/ansible/ansible.cfg as config file
+Skipping callback 'default', as we already have a stdout callback.
+Skipping callback 'minimal', as we already have a stdout callback.
+Skipping callback 'oneline', as we already have a stdout callback.
+
+PLAYBOOK: site.yml *************************************************************
+1 plays in playbooks/site.yml
+
+PLAY [Configure environment on servers] ****************************************
+
+TASK [Gathering Facts] *********************************************************
+task path: /workspace/ansible/playbooks/site.yml:2
+ok: [localhost]
+
+TASK [base : Ensure apt cache is up to date] ***********************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:2
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Install base packages] ********************************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:8
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Create application user] ******************************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:14
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Create application root directory] ********************************
+task path: /workspace/ansible/roles/base/tasks/main.yml:22
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [base : Optionally enable UFW and allow SSH and HTTP] *********************
+task path: /workspace/ansible/roles/base/tasks/main.yml:31
+skipping: [localhost] => {"changed": false, "false_condition": "(enable_ufw | default(false)) | bool", "skip_reason": "Conditional result was False"}
+
+TASK [git : Install git packages] **********************************************
+task path: /workspace/ansible/roles/git/tasks/main.yml:2
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [git : Configure global git safe.directory for app path (optional)] *******
+task path: /workspace/ansible/roles/git/tasks/main.yml:9
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [nginx : Install nginx] ***************************************************
+task path: /workspace/ansible/roles/nginx/tasks/main.yml:2
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [nginx : Ensure nginx service is enabled and started] *********************
+task path: /workspace/ansible/roles/nginx/tasks/main.yml:9
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [nginx : Create web root] *************************************************
+task path: /workspace/ansible/roles/nginx/tasks/main.yml:16
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [nginx : Deploy nginx site config] ****************************************
+task path: /workspace/ansible/roles/nginx/tasks/main.yml:25
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [nginx : Enable site] *****************************************************
+task path: /workspace/ansible/roles/nginx/tasks/main.yml:35
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+TASK [nginx : Remove default site if present] **********************************
+task path: /workspace/ansible/roles/nginx/tasks/main.yml:44
+skipping: [localhost] => {"changed": false, "false_condition": "ansible_connection != 'local'", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=13   rescued=0    ignored=0   
+

--- a/ansible/logs/syntax_check.log
+++ b/ansible/logs/syntax_check.log
@@ -1,0 +1,25 @@
+2025-09-28T10:32:25+00:00 Starting syntax check
+ERROR! unexpected parameter type in action: <class 'ansible.parsing.yaml.objects.AnsibleSequence'>
+
+The error appears to be in '/workspace/ansible/roles/base/tasks/main.yml': line 27, column 3, but may
+be elsewhere in the file depending on the exact syntax problem.
+
+The offending line appears to be:
+
+
+- name: Optionally enable UFW and allow SSH and HTTP
+  ^ here
+2025-09-28T10:33:05+00:00 Re-running syntax check
+ERROR! couldn't resolve module/action 'community.general.ufw'. This often indicates a misspelling, missing collection, or incorrect module path.
+
+The error appears to be in '/workspace/ansible/roles/base/tasks/main.yml': line 34, column 7, but may
+be elsewhere in the file depending on the exact syntax problem.
+
+The offending line appears to be:
+
+
+    - name: Allow OpenSSH
+      ^ here
+2025-09-28T10:33:41+00:00 Re-running syntax check after ufw split
+
+playbook: playbooks/site.yml

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure environment on servers
+  hosts: all
+  become: "{{ ansible_connection != 'local' }}"
+  vars:
+    app_root_dir: "{{ app_root_dir | default('/var/www/app') }}"
+  roles:
+    - role: base
+    - role: git
+    - role: nginx
+

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: community.general
+    version: ">=8.0.0,<9.0.0"
+

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Ensure apt cache is up to date
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+  when: ansible_connection != 'local'
+
+- name: Install base packages
+  ansible.builtin.apt:
+    name: "{{ base_packages }}"
+    state: present
+  when: ansible_connection != 'local'
+
+- name: Create application user
+  ansible.builtin.user:
+    name: "{{ app_user }}"
+    shell: /bin/bash
+    create_home: true
+    system: true
+  when: ansible_connection != 'local'
+
+- name: Create application root directory
+  ansible.builtin.file:
+    path: "{{ app_root_dir }}"
+    state: directory
+    owner: "{{ app_user }}"
+    group: "{{ app_user }}"
+    mode: "0755"
+  when: ansible_connection != 'local'
+
+- name: Optionally enable UFW and allow SSH and HTTP
+  ansible.builtin.include_tasks: ufw.yml
+  when: (enable_ufw | default(false)) | bool
+

--- a/ansible/roles/base/tasks/ufw.yml
+++ b/ansible/roles/base/tasks/ufw.yml
@@ -1,0 +1,26 @@
+---
+- name: Install ufw
+  ansible.builtin.apt:
+    name: ufw
+    state: present
+  when: ansible_connection != 'local'
+
+- name: Allow OpenSSH
+  community.general.ufw:
+    rule: allow
+    name: OpenSSH
+  when: ansible_connection != 'local'
+
+- name: Allow HTTP
+  community.general.ufw:
+    rule: allow
+    port: "{{ nginx_listen_port }}"
+    proto: tcp
+  when: ansible_connection != 'local'
+
+- name: Enable firewall
+  community.general.ufw:
+    state: enabled
+    policy: deny
+  when: ansible_connection != 'local'
+

--- a/ansible/roles/git/tasks/main.yml
+++ b/ansible/roles/git/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Install git packages
+  ansible.builtin.apt:
+    name: "{{ git_packages }}"
+    state: present
+    update_cache: true
+  when: ansible_connection != 'local'
+
+- name: Configure global git safe.directory for app path (optional)
+  ansible.builtin.command:
+    cmd: git config --system --add safe.directory "{{ app_root_dir }}"
+  changed_when: false
+  failed_when: false
+  when: ansible_connection != 'local'
+

--- a/ansible/roles/nginx/handlers/main.yml
+++ b/ansible/roles/nginx/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload nginx
+  ansible.builtin.service:
+    name: nginx
+    state: reloaded
+

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Install nginx
+  ansible.builtin.apt:
+    name: "{{ nginx_packages }}"
+    state: present
+    update_cache: true
+  when: ansible_connection != 'local'
+
+- name: Ensure nginx service is enabled and started
+  ansible.builtin.service:
+    name: nginx
+    state: started
+    enabled: true
+  when: ansible_connection != 'local'
+
+- name: Create web root
+  ansible.builtin.file:
+    path: "{{ app_root_dir }}"
+    state: directory
+    owner: "{{ app_user }}"
+    group: "{{ app_user }}"
+    mode: "0755"
+  when: ansible_connection != 'local'
+
+- name: Deploy nginx site config
+  ansible.builtin.template:
+    src: site.conf.j2
+    dest: "/etc/nginx/sites-available/{{ nginx_site_name }}.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload nginx
+  when: ansible_connection != 'local'
+
+- name: Enable site
+  ansible.builtin.file:
+    src: "/etc/nginx/sites-available/{{ nginx_site_name }}.conf"
+    dest: "/etc/nginx/sites-enabled/{{ nginx_site_name }}.conf"
+    state: link
+    force: true
+  notify: Reload nginx
+  when: ansible_connection != 'local'
+
+- name: Remove default site if present
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  notify: Reload nginx
+  when: ansible_connection != 'local'
+

--- a/ansible/roles/nginx/templates/site.conf.j2
+++ b/ansible/roles/nginx/templates/site.conf.j2
@@ -1,0 +1,20 @@
+server {
+    listen {{ nginx_listen_port }} default_server;
+    server_name {{ nginx_server_name }};
+
+    access_log /var/log/nginx/{{ nginx_site_name }}.access.log;
+    error_log  /var/log/nginx/{{ nginx_site_name }}.error.log;
+
+    root {{ app_root_dir }};
+    index index.html;
+
+    location /health {
+        return 200 'ok';
+        add_header Content-Type text/plain;
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+


### PR DESCRIPTION
Add an Ansible playbook to automate Yandex Cloud VM environment setup, including Nginx, Git, and base dependencies, with all configurations stored in the repository.

The playbook is structured with roles for base packages, Git, and Nginx, and includes inventories for both Yandex Cloud and local testing. Tasks are conditionally skipped during local dry-runs to prevent system modifications, and logs from a local syntax check and dry-run are provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-54fbb254-cc2b-4426-97bc-269f8eb755cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54fbb254-cc2b-4426-97bc-269f8eb755cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

